### PR TITLE
add Raspberry Pi Debug Probe into the list of supported  CMSIS-DAP devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,12 +494,13 @@
                 const device = await navigator.usb.requestDevice({
                     filters: [
                         { vendorId: 0x2886 },  // Seeed Technology Co., Ltd.
+                        { vendorId: 0x2e8a },  // Raspberry Pi Foundation
                     ]
                 });
                 return device;
             } catch (error) {
                 if (error.name === 'NotFoundError') {
-                    throw new Error('No device selected. Please select a Seeed CMSIS-DAP device.');
+                    throw new Error('No device selected. Please select a CMSIS-DAP device.');
                 }
                 throw error;
             }


### PR DESCRIPTION
It was confirmed that Raspberry Pi Debug Probe can operate with XIAO nRF54L15.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/uist1idrju3i/xiao-nrf54l15-web-flasher/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
